### PR TITLE
Correct Roadmap Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you'd like to change the theme's HTML layout:
 
 ## Roadmap
 
-See the [open issues](https://github.com/pagse-themes/minimal/issues) for a list of proposed features (and known issues).
+See the [open issues](https://github.com/pages-themes/minimal/issues) for a list of proposed features (and known issues).
 
 ## Project philosophy
 


### PR DESCRIPTION
Roadmap link had two letters flipped and was broken. This change fixes that.