### PR TITLE
added link to home in header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
   <body>
     <div class="wrapper">
       <header>
-        <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        <a href="{{ site.github.url }}"> <h1>{{ site.title | default: site.github.repository_name }}</h1> </a>
         <p>{{ site.description | default: site.github.project_tagline }}</p>
 
         {% if site.github.is_project_page %}


### PR DESCRIPTION
I thought it would be a nice thing to be able to go back to home page from any other page. So in the header, I've put the `h1` tag in a `a` tag with href  `{{ site.github.url }}`.