### PR TITLE
make font-size relative in <code> and <pre>

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -70,7 +70,6 @@ blockquote {
 code, pre {
   font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace;
   color:#333;
-  font-size:12px;
 }
 
 pre {


### PR DESCRIPTION
If the font size in `<pre>` and `<code>` is fixed, using it in headings is weird.

Making the font size in those elements relative fixes the issue.

Just in case it helps.