### PR TITLE
Add `downloads` SCSS class for download lists

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
         {% endif %}
 
         {% if site.show_downloads %}
-        <ul>
+        <ul class="downloads">
           <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
           <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
           <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -111,7 +111,7 @@ header {
   -webkit-font-smoothing:subpixel-antialiased;
 }
 
-header ul {
+ul.downloads {
   list-style:none;
   height:40px;
   padding:0;
@@ -121,22 +121,22 @@ header ul {
   width:270px;
 }
 
-header li {
+.downloads li {
   width:89px;
   float:left;
   border-right:1px solid #e0e0e0;
   height:40px;
 }
 
-header li:first-child a {
+.downloads li:first-child a {
   border-radius:5px 0 0 5px;
 }
 
-header li:last-child a {
+.downloads li:last-child a {
   border-radius:0 5px 5px 0;
 }
 
-header ul a {
+.downloads a {
   line-height:1;
   font-size:11px;
   color:#676767;
@@ -146,12 +146,12 @@ header ul a {
   height:34px;
 }
 
-header ul a:hover, header ul a:focus {
+.downloads a:hover, .downloads a:focus {
   color:#675C5C;
   font-weight:bold;
 }
 
-header ul a:active {
+.downloads ul a:active {
   background-color:#f0f0f0;
 }
 
@@ -160,12 +160,12 @@ strong {
   font-weight:700;
 }
 
-header ul li + li + li {
+.downloads li + li + li {
   border-right:none;
   width:89px;
 }
 
-header ul a strong {
+.downloads a strong {
   font-size:14px;
   display:block;
   color:#222;
@@ -254,11 +254,11 @@ footer {
     padding:15px;
   }
 
-  header ul {
+  .downloads {
     width:99%;
   }
 
-  header li, header ul li + li + li {
+  .downloads li, .downloads li + li + li {
     width:33%;
   }
 }


### PR DESCRIPTION
In order for the downloads list to render differently from other `ul`s in the header while still making regular `ul`s easy to style, it is necessary for it to implement a separate class.  Implement the `downloads` class to represent this special type of list.

Fixes #34.
Fixes #19.

## Before:
![image](https://user-images.githubusercontent.com/5448053/40526748-612083a0-5f9d-11e8-9385-f6ecf2c058c6.png)

## After:
![image](https://user-images.githubusercontent.com/5448053/40526754-6b047aca-5f9d-11e8-968c-cc1d8d8f153a.png)