### PR TITLE
favicon support for github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If you'd like to add your own custom styles:
     ```
 3. Add any custom CSS (or Sass, including imports) you'd like immediately after the `@import` line
 
+### Logo and Favicon
+Copy your logo and favicon.ico to /assets/img. The default file name for your
+logo is logo.png. The logo filename can be changed in `_config.ymp`.
+
 ### Layouts
 
 If you'd like to change the theme's HTML layout:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
 
 {% seo %}
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | prepend: site.baseurl }}">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->


### PR DESCRIPTION
Putting a favicon.ico in the top directory works when using Jekyll local.  But when I moved my documentation to github pages the favicon.ico did not display.  Adding a link for the favicon in `_layouts/default.html` resolved the issue of the missing favicon with github pages.