### PR TITLE
Feature: Add an option to disable description in the sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,4 @@ description: Minimal is a theme for GitHub Pages.
 show_downloads: true
 google_analytics:
 theme: jekyll-theme-minimal
+show_description: true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,9 @@
           <img src="{{site.logo | relative_url}}" alt="Logo" />
         {% endif %}
 
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
+        {% unless site.show_description == false %}
+          <p>{{ site.description | default: site.github.project_tagline }}</p>
+        {% endunless %}
 
         {% if site.github.is_project_page %}
         <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>


### PR DESCRIPTION
# Description

I use this theme for [one](https://tildehacker.com/ideapad-conservation-mode) of my projects to showcase the README file. The project description is already included in the README file so I added a variable called show_description to _config.yml to let me disable the description in the sidebar.

This change is non-breaking. If there is no show_description variable in _config.yml, the description is still shown as before.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How has this been tested?

This was tested locally using `bundle exec jekyll serve` command and remotely on my project [page](https://tildehacker.com/ideapad-conservation-mode).

# Checklist:

- [ ] I have made corresponding changes to the documentation