### PR TITLE
Fix: Add .jekyll-cache/ and .jekyll-metadata to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site
 .sass-cache
 Gemfile.lock
 *.gem
+.jekyll-cache/
+.jekyll-metadata


### PR DESCRIPTION
# Description

When I was working on adding some new features to this theme, I noticed a folder called `.jekyll-cache/` in the project directory that was generated by the `bundle exec jekyll serve` command. It is a generated folder that needs to be ignored by Git.

I noticed that `.jekyll-metadata` is missing from `.gitignore` file too, so I added both of them. I compared the `.gitignore` file with this [file](https://github.com/github/gitignore/blob/master/Jekyll.gitignore).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

The directory does not show up anymore when running `git status`.