### PR TITLE
Feature: Show GitHub avatar in sidebar when there is no logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,5 @@ description: Minimal is a theme for GitHub Pages.
 show_downloads: true
 google_analytics:
 theme: jekyll-theme-minimal
+use_github_avatar: true
+github_username: pages-themes

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,8 @@
         
         {% if site.logo %}
           <img src="{{site.logo | relative_url}}" alt="Logo" />
+        {% elsif site.use_github_avatar == true and site.github_username %}
+          <img src="https://github.com/{{ site.github_username }}.png" alt="Logo" />
         {% endif %}
 
         <p>{{ site.description | default: site.github.project_tagline }}</p>


### PR DESCRIPTION
# Description

I use this theme for one of my projects that does not have a logo. Instead of leaving the space empty, I added my GitHub avatar to fill the space.

For this, I added two new variables:
- use_github_avatar: When set to true, the GitHub's avatar of `github_username` will be shown if there is no logo;
- github_username: This variable is added to set a custom GitHub username.

This change is non-breaking:
- If there is a logo, this change will not take effect;
- Old repositories without `use_github_avatar` and `github_username` variables will continue to work correctly.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How has this been tested?

I tested both locally using `bundle exec jekyll serve`, and remotely on my own GitHub Pages hosted [project](https://tildehacker.com/ideapad-conservation-mode).

# Checklist:

- [ ] I have made corresponding changes to the documentation