### PR TITLE
Fix: Overlapping header and footer in the sidebar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,4 @@
+{% if site.github.is_project_page %}
+<p>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+{% endif %}
+<p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div class="wrapper">
-      <sidebar>
+      <div class="sidebar">
         <header>
           <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
           
@@ -42,7 +42,7 @@
         <div class="sidebar-footer">
           {%- include footer.html -%}
         </div>
-      </sidebar>
+      </div>
       <section>
 
       {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,31 +13,33 @@
   </head>
   <body>
     <div class="wrapper">
-      <header>
-        <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-        
-        {% if site.logo %}
-          <img src="{{site.logo | relative_url}}" alt="Logo" />
-        {% endif %}
+      <sidebar>
+        <header>
+          <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+          
+          {% if site.logo %}
+            <img src="{{site.logo | relative_url}}" alt="Logo" />
+          {% endif %}
 
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
+          <p>{{ site.description | default: site.github.project_tagline }}</p>
 
-        {% if site.github.is_project_page %}
-        <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
-        {% endif %}
+          {% if site.github.is_project_page %}
+          <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
+          {% endif %}
 
-        {% if site.github.is_user_page %}
-        <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
-        {% endif %}
+          {% if site.github.is_user_page %}
+          <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
+          {% endif %}
 
-        {% if site.show_downloads %}
-        <ul class="downloads">
-          <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
-          <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
-        </ul>
-        {% endif %}
-      </header>
+          {% if site.show_downloads %}
+          <ul class="downloads">
+            <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
+            <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
+            <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
+          </ul>
+          {% endif %}
+        </header>
+      </sidebar>
       <section>
 
       {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,6 +39,9 @@
           </ul>
           {% endif %}
         </header>
+        <div class="sidebar-footer">
+          {%- include footer.html -%}
+        </div>
       </sidebar>
       <section>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,10 +44,7 @@
 
       </section>
       <footer>
-        {% if site.github.is_project_page %}
-        <p>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
-        {% endif %}
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
+        {%- include footer.html -%}
       </footer>
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -203,7 +203,7 @@ hr {
   margin:0 0 20px;
 }
 
-footer {
+footer, .sidebar-footer {
   width:270px;
   float:left;
   bottom:50px;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -117,6 +117,13 @@ sidebar {
   height: calc(100vh - 108px);
   overflow-x: hidden;
   overflow-y: scroll;
+  scrollbar-width: none; // Firefox
+  -ms-overflow-style: -ms-autohiding-scrollbar; // IE10+
+}
+
+sidebar::-webkit-scrollbar {
+  /* Chrome, Safari, Edge */
+  display: none;
 }
 
 ul.downloads {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -231,6 +231,10 @@ footer {
     display: initial;
   }
 
+  .sidebar-footer {
+    display: none;
+  }
+
   div.wrapper {
     width:auto;
     margin:0;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -104,7 +104,7 @@ img {
   max-width:100%;
 }
 
-header {
+sidebar {
   width:270px;
   float:left;
   position:fixed;
@@ -203,7 +203,7 @@ footer {
     margin:0;
   }
 
-  header, section, footer {
+  sidebar, section, footer {
     float:none;
     position:static;
     width:auto;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -206,7 +206,6 @@ hr {
 footer {
   width:270px;
   float:left;
-  position:fixed;
   bottom:50px;
   -webkit-font-smoothing:subpixel-antialiased;
 }

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -117,8 +117,16 @@ img {
   height: calc(100vh - 108px);
   overflow-x: hidden;
   overflow-y: scroll;
-  scrollbar-width: none; // Firefox
   -ms-overflow-style: -ms-autohiding-scrollbar; // IE10+
+}
+
+// Disables the scrollbar in Firefox
+// HTML-Proofer fails without "@-moz-document url-prefix()"
+// because scrollbar-width is still experimental in Firefox.
+@-moz-document url-prefix() {
+  .sidebar {
+    scrollbar-width: none;
+  }
 }
 
 .sidebar::-webkit-scrollbar {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -115,6 +115,8 @@ sidebar {
   flex-direction: column;
   justify-content: space-between;
   height: calc(100vh - 108px);
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 ul.downloads {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -110,6 +110,7 @@ sidebar {
   position:fixed;
   -webkit-font-smoothing:subpixel-antialiased;
   top: 0;
+  padding: 58px 0 50px 0;
 }
 
 ul.downloads {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -220,6 +220,13 @@ footer {
 
 @media print, screen and (max-width: 960px) {
 
+  sidebar {
+    padding: initial;
+    display: initial;
+    height: initial;
+    overflow: initial;    
+  }
+
   div.wrapper {
     width:auto;
     margin:0;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -111,6 +111,10 @@ sidebar {
   -webkit-font-smoothing:subpixel-antialiased;
   top: 0;
   padding: 58px 0 50px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(100vh - 108px);
 }
 
 ul.downloads {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -214,6 +214,10 @@ footer {
   display: none;
 }
 
+.sidebar-footer {
+  flex-basis: content;
+}
+
 @media print, screen and (max-width: 960px) {
 
   div.wrapper {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -104,7 +104,7 @@ img {
   max-width:100%;
 }
 
-sidebar {
+.sidebar {
   width:270px;
   float:left;
   position:fixed;
@@ -121,7 +121,7 @@ sidebar {
   -ms-overflow-style: -ms-autohiding-scrollbar; // IE10+
 }
 
-sidebar::-webkit-scrollbar {
+.sidebar::-webkit-scrollbar {
   /* Chrome, Safari, Edge */
   display: none;
 }
@@ -220,7 +220,7 @@ footer {
 
 @media print, screen and (max-width: 960px) {
 
-  sidebar {
+  .sidebar {
     padding: initial;
     display: initial;
     height: initial;
@@ -240,7 +240,7 @@ footer {
     margin:0;
   }
 
-  sidebar, section, footer {
+  .sidebar, section, footer {
     float:none;
     position:static;
     width:auto;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -210,6 +210,10 @@ footer, .sidebar-footer {
   -webkit-font-smoothing:subpixel-antialiased;
 }
 
+footer {
+  display: none;
+}
+
 @media print, screen and (max-width: 960px) {
 
   div.wrapper {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -227,6 +227,10 @@ footer {
     overflow: initial;    
   }
 
+  footer {
+    display: initial;
+  }
+
   div.wrapper {
     width:auto;
     margin:0;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -141,11 +141,11 @@ ul.downloads {
   background: #f4f4f4;
   border-radius:5px;
   border:1px solid #e0e0e0;
-  width:270px;
+  width:268px;
 }
 
 .downloads li {
-  width:89px;
+  width:88px;
   float:left;
   border-right:1px solid #e0e0e0;
   height:40px;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -109,6 +109,7 @@ sidebar {
   float:left;
   position:fixed;
   -webkit-font-smoothing:subpixel-antialiased;
+  top: 0;
 }
 
 ul.downloads {


### PR DESCRIPTION
# Description

When the View-port height gets too small, the header and the footer overlap.

This pull request relies on the [Flex-box](https://css-tricks.com/snippets/css/a-guide-to-flexbox) feature of CSS.

You can see a live preview of this fix on my [project page](https://tildehacker.com/ideapad-conservation-mode).

I did my best to keep this pull request limited to View-port sizes greater than 960px. Anything related to styling View-ports lower than 960px was kept as it is.

The changes are explained in more detail in the commits messages.

For those of you who want to include this fix in their GitHub Pages projects before it gets merged, use:

```
remote_theme: tildehacker/minimal@e0ea159aa5b010093640f661c8c8a05677540c0a
```

instead of:

```
theme: jekyll-theme-minimal
```

in your `_config.yml` file.

## Screen-cast before the fix

![before-viewport-getting-smaller](https://user-images.githubusercontent.com/30960791/82530326-f472f280-9b34-11ea-98cc-8c20cd80afd8.gif)

## Screen-casts after the fix

When the View-port is too small.

![after-small-viewport](https://user-images.githubusercontent.com/30960791/82530389-153b4800-9b35-11ea-8cba-0f885577444a.gif)

When the View-port is large enough.

![after-large-viewport](https://user-images.githubusercontent.com/30960791/82530430-30a65300-9b35-11ea-8a0a-6e85f11206cf.gif)

Fixes #71 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Running the continuous integration script (`script/cibuild`);
- Manually testing using the latest version of Firefox;
- Manually testing using the latest version of Chrome.

**Test configuration**:
* Arch Linux
* Latest version of Firefox
* Latest version of Chrome