### PR TITLE
Option to hide description in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ description: [A short description of your site's purpose]
 Additionally, you may choose to set the following optional variables:
 
 ```yml
+show_description: ["true" or "false" (unquoted) to indicate whether to show or hide the description in the side bar - defaults to "true"]
 show_downloads: ["true" or "false" (unquoted) to indicate whether to provide a download URL]
 google_analytics: [Your Google Analytics tracking ID]
 ```

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,9 @@
           <img src="{{site.logo | relative_url}}" alt="Logo" />
         {% endif %}
 
+        {% if site.hide_description_in_side_bar != true %}
         <p>{{ site.description | default: site.github.project_tagline }}</p>
+        {% endif %}
 
         {% if site.github.is_project_page %}
         <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,8 @@
           <img src="{{site.logo | relative_url}}" alt="Logo" />
         {% endif %}
 
-        {% if site.hide_description_in_side_bar != true %}
+        {% assign visible_description = site.show_description | default: true %}
+        {% if visible_description %}
         <p>{{ site.description | default: site.github.project_tagline }}</p>
         {% endif %}
 


### PR DESCRIPTION
Added option to hide the description in the header. The reclaimed space can help display other things such as stats or custom links