### PR TITLE
fix(docs): Update link of large image

### DIFF
--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://docs.github.com/get-started/quickstart/hello-world)
+![Branching](https://docs.github.com/assets/images/help/repository/branching.png)
 
 
 ### Definition lists can be used with HTML syntax.

--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://guides.github.com/activities/hello-world/branching.png)
+![Branching](https://docs.github.com/get-started/quickstart/hello-world)
 
 
 ### Definition lists can be used with HTML syntax.


### PR DESCRIPTION
`Hello World` guide was moved.

From: https://guides.github.com/activities/hello-world
To:   https://docs.github.com/get-started/quickstart/hello-world

so update accordingly