### PR TITLE
Prevent text overlap of footer and paragraph tags

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -188,7 +188,7 @@ strong {
 section {
   width:500px;
   float:right;
-  padding-bottom:50px;
+  padding-bottom:30px;
 }
 
 small {
@@ -206,7 +206,7 @@ footer {
   width:270px;
   float:left;
   position:fixed;
-  bottom:50px;
+  bottom:30px;
   -webkit-font-smoothing:subpixel-antialiased;
 }
 


### PR DESCRIPTION
# Fixes Text Overflow In Left Column

When the "View this project on GitHub" and "This project is maintained by" are moved to the same left column (width > 960px), an overlap occurs on screens with aspect ratio > 1.25. For example, on a screen of 1920 × 1080, the ratio ≈ 1.78.

## Bugged and Fixed

![ezgif com-gif-maker](https://user-images.githubusercontent.com/25377399/144313159-be85cadd-ff0f-4f78-89db-aa732ed082d9.gif)

## Reasoning

The most common maximum aspect ratio is 2.35, but the average is 1.5.

Run:
```javascript
let total = 0;
let ratios = 0;

document.querySelectorAll("td[style='text-align:center;']").forEach(node => {
    let prevNode = node.previousElementSibling;
    let nextNode = node.nextElementSibling;
    if (prevNode?.style?.textAlign == 'center' && nextNode?.style?.textAlign == 'center') {
        const wh = node.innerText.split('∶');
        const w = parseFloat(wh[0]);
        const h = parseFloat(wh[1]);
        if (w / h) {
            ratios += w / h;
            total += 1;
        }
    }
});

console.log(ratios / total);
```
on [https://en.wikipedia.org/wiki/List_of_common_resolutions](https://en.wikipedia.org/wiki/List_of_common_resolutions) to confirm.

# Fix

By changing where the bottom occurs, this overflow is prevented on most common screen sizes. I decreased the bottom from 50px to 30px since most bottom paddings are 20px. This change still leaves ample room at the bottom, but it means that fewer screens will experience overlapping text.