### PR TITLE
fix the main text color for weak-sighted people

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -5,7 +5,7 @@ body {
   background-color: #fff;
   padding:50px;
   font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color:#727272;
+  color:#444;
   font-weight:400;
 }
 


### PR DESCRIPTION
Hi, team!

I've found the primary text color of this theme[^this] is too hard to read for weak-sighted people (yes, it's me). So it would be nice if this PR could be reviewed and merged. 

[^this]: Found this issue on reading https://rust-gcc.github.io/2023/04/24/gccrs-and-gcc13-release.html  I am almost not able to read this blog entry.